### PR TITLE
Request a signed texture payload from Mojang

### DIFF
--- a/src/main/java/org/spacehq/mc/auth/SessionService.java
+++ b/src/main/java/org/spacehq/mc/auth/SessionService.java
@@ -129,7 +129,7 @@ public class SessionService {
 		}
 
 		try {
-			URL url = URLUtils.constantURL("https://sessionserver.mojang.com/session/minecraft/profile/" + UUIDSerializer.fromUUID(profile.getId()));
+			URL url = URLUtils.constantURL("https://sessionserver.mojang.com/session/minecraft/profile/" + UUIDSerializer.fromUUID(profile.getId()) + "?unsigned=false");
 			MinecraftProfilePropertiesResponse response = URLUtils.makeRequest(url, null, MinecraftProfilePropertiesResponse.class);
 			if(response == null) {
 				throw new ProfileNotFoundException("Couldn't fetch profile properties for " + profile + " as the profile does not exist.");


### PR DESCRIPTION
MCAuthLib expects a signed textures payload, but doesn't request one. This causes texture verification to always fail.

This PR fixes this problem. I have tested this locally and it does indeed fix the issue.
