### PR TITLE
Improved documentation + small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MCAuthLib is a library for authentication with Minecraft accounts. It is used in
 See [example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java](https://github.com/GeyserMC/MCAuthLib/blob/master/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java) for example usage.
 
 ## Installing as a dependency
-Most developers should be using MCAuthLib through MCProtocolLib, but you can also use it independently. The recommended way of installing MCAuthLib is through [JitPack](https://jitpack.io). For more details, [see MCAuthLib on JitPack](https://jitpack.io/#Steveice10/MCAuthLib).
+Most developers should be using MCAuthLib through MCProtocolLib, but you can also use it independently. The recommended way of installing MCAuthLib is through [JitPack](https://jitpack.io). For more details, [see MCAuthLib on JitPack](https://jitpack.io/#GeyserMC/MCAuthLib).
 
 Maven:
 ```xml
@@ -17,7 +17,7 @@ Maven:
 </repositories>
 
 <dependency>
-    <groupId>com.github.Steveice10</groupId>
+    <groupId>com.github.GeyserMC</groupId>
     <artifactId>MCAuthLib</artifactId>
     <version>(version here)</version>
 </dependency>
@@ -32,7 +32,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.github.Steveice10:MCAuthLib:(version here)'
+    implementation 'com.github.GeyserMC:MCAuthLib:(version here)'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 # MCAuthLib
-MCAuthLib is a library for authentication with Minecraft accounts. It is used in projects such as MCProtocolLib to handle authenticating users.
+MCAuthLib is a library for authentication with Minecraft accounts. It is used in projects such as [MCProtocolLib](https://github.com/GeyserMC/MCProtocolLib) to handle authenticating users.
 
 ## Example Code
-See [example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java](https://github.com/Steveice10/MCAuthLib/blob/master/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java)
+See [example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java](https://github.com/GeyserMC/MCAuthLib/blob/master/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java) for example usage.
 
-## Building the Source
-MCAuthLib uses Maven to manage dependencies. Simply run 'mvn clean install' in the source's directory.
+## Installing as a dependency
+Most developers should be using MCAuthLib through MCProtocolLib, but you can also use it independently. The recommended way of installing MCAuthLib is through [JitPack](https://jitpack.io). For more details, [see MCAuthLib on JitPack](https://jitpack.io/#Steveice10/MCAuthLib).
+
+Maven:
+```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+
+<dependency>
+    <groupId>com.github.Steveice10</groupId>
+    <artifactId>MCAuthLib</artifactId>
+    <version>(version here)</version>
+</dependency>
+```
+
+Gradle:
+```groovy
+allprojects {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
+}
+
+dependencies {
+    implementation 'com.github.Steveice10:MCAuthLib:(version here)'
+}
+```
+
+## Building the source
+MCAuthLib uses Maven to manage dependencies. To build the source code, run `mvn clean install` in the project root directory.
 
 ## Support and development
-
-Please join us at https://discord.gg/geysermc under #mcprotocollib for discussion and support for this project.
+Please join [our Discord server](https://discord.gg/geysermc) and visit the **#mcprotocollib** channel for discussion and support for this project.
 
 ## License
 MCAuthLib is licensed under the **[MIT license](http://www.opensource.org/licenses/mit-license.html)**.
-

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.7</jdk.version>
-        <argLine/>
+        <argLine></argLine>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -10,18 +10,18 @@
 
     <name>MCAuthLib</name>
     <description>A library for authentication with Minecraft accounts.</description>
-    <url>http://github.com/Steveice10/MCAuthLib/</url>
+    <url>http://github.com/GeyserMC/MCAuthLib/</url>
 
     <scm>
-        <connection>scm:git:git@github.com:Steveice10/MCAuthLib.git</connection>
-        <developerConnection>scm:git:git@github.com:Steveice10/MCAuthLib.git</developerConnection>
-        <url>git@github.com:Steveice10/MCAuthLib/</url>
+        <connection>scm:git:git@github.com:GeyserMC/MCAuthLib.git</connection>
+        <developerConnection>scm:git:git@github.com:GeyserMC/MCAuthLib.git</developerConnection>
+        <url>git@github.com:GeyserMC/MCAuthLib/</url>
     </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.7</jdk.version>
-        <argLine></argLine>
+        <argLine/>
     </properties>
 
     <licenses>
@@ -42,14 +42,14 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/Steveice10/MCAuthLib/issues</url>
+        <url>https://github.com/GeyserMC/MCAuthLib/issues</url>
     </issueManagement>
 
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.2</version>
+            <version>2.8.8</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/github/steveice10/mc/auth/util/HTTP.java
+++ b/src/main/java/com/github/steveice10/mc/auth/util/HTTP.java
@@ -5,7 +5,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import jdk.nashorn.internal.objects.NativeArray;
 
 import java.io.*;
 import java.net.HttpURLConnection;


### PR DESCRIPTION
Mostly improvements to the README (better formatting, more links/info).

Some lines in `pom.xml` switched from referencing `Steveice10/MCAuthLib` to `GeyserMC/MCAuthLib` because the old repository redirects here anyways, so the Maven info may as well have this updated information too.

Last thing: small fix in `HTTP.java`, I had to remove an unused `import` that was causing compilation to fail.