### PR TITLE
Added ability to refresh tokens and re-authenticate using refresh token

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -295,7 +295,7 @@ public class MsaAuthenticationService extends AuthenticationService {
 
         protected MsCodeRequest(String clientId) {
             this.client_id = clientId;
-            this.scope = "XboxLive.signin";
+            this.scope = "XboxLive.signin offline_access";
         }
 
         public Map<String, String> toMap() {

--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -342,8 +342,15 @@ public class MsaAuthenticationService extends AuthenticationService {
         private String scope;
 
         protected MsCodeRequest(String clientId) {
+            this(clientId, false);
+        }
+
+        /**
+         * @param offlineAccess Set to true to request offline access for the refresh token, allowing re-authentication.
+         */
+        protected MsCodeRequest(String clientId, boolean offlineAccess) {
             this.client_id = clientId;
-            this.scope = "XboxLive.signin offline_access";
+            this.scope = "XboxLive.signin" + (offlineAccess ? " offline_access" : "");
         }
 
         public Map<String, String> toMap() {

--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -38,6 +38,7 @@ public class MsaAuthenticationService extends AuthenticationService {
 
     private String deviceCode;
     private String clientId;
+    private String refreshToken;
 
     public MsaAuthenticationService(String clientId) {
         this(clientId, null);
@@ -52,6 +53,21 @@ public class MsaAuthenticationService extends AuthenticationService {
 
         this.clientId = clientId;
         this.deviceCode = deviceCode;
+    }
+
+    /**
+     * Gets the current refresh token for this session
+     */
+    public String getRefreshToken() {
+        return this.refreshToken;
+    }
+
+    /**
+     * Sets a new refresh token. Useful for re-authenticating from device code authorizations.
+     * @param refreshToken The refresh token to set
+     */
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     /**
@@ -83,7 +99,7 @@ public class MsaAuthenticationService extends AuthenticationService {
         }
         MsCodeTokenRequest request = new MsCodeTokenRequest(this.clientId, this.deviceCode);
         MsTokenResponse response = HTTP.makeRequestForm(this.getProxy(), MS_CODE_TOKEN_ENDPOINT, request.toMap(), MsTokenResponse.class);
-
+        this.refreshToken = response.refresh_token;
         return getLoginResponseFromToken("d=" + response.access_token);
     }
 
@@ -165,7 +181,7 @@ public class MsaAuthenticationService extends AuthenticationService {
 
         MsTokenRequest request = new MsTokenRequest(clientId, code);
         MsTokenResponse response = HTTP.makeRequestForm(this.getProxy(), MS_TOKEN_ENDPOINT, request.toMap(), MsTokenResponse.class);
-
+        this.refreshToken = response.refresh_token;
         return getLoginResponseFromToken(response.access_token);
     }
 
@@ -179,6 +195,33 @@ public class MsaAuthenticationService extends AuthenticationService {
         }
 
         return textBuilder.toString();
+    }
+
+    /**
+     * Refreshes the access token and refresh token for further use
+     *
+     * @return The response containing the refresh token, so the user can store it for later use.
+     * @throws RequestException
+     */
+    public MsTokenResponse refreshToken() throws RequestException {
+        if (this.refreshToken == null) {
+            throw new InvalidCredentialsException("Invalid refresh token.");
+        }
+
+        MsTokenResponse response = HTTP.makeRequestForm(this.getProxy(), MS_TOKEN_ENDPOINT, new MsRefreshRequest(clientId, refreshToken).toMap(), MsTokenResponse.class);
+        accessToken = response.access_token;
+        refreshToken = response.refresh_token;
+
+        return response;
+    }
+
+    /**
+     * Attempt to sign in using an existing refresh token set by {@link #setRefreshToken(String)}
+     *
+     * @throws RequestException
+     */
+    private McLoginResponse getLoginResponseFromRefreshToken() throws RequestException {
+        return getLoginResponseFromToken("d=".concat(refreshToken().access_token));
     }
 
     /**
@@ -232,20 +275,25 @@ public class MsaAuthenticationService extends AuthenticationService {
         boolean token = this.clientId != null && !this.clientId.isEmpty();
         boolean device = this.deviceCode != null && !this.deviceCode.isEmpty();
         boolean password = this.password != null && !this.password.isEmpty();
-        if(!token && !password) {
+        boolean refresh = this.refreshToken != null && !this.refreshToken.isEmpty();
+
+        if(!token && !password && !refresh) {
             throw new InvalidCredentialsException("Invalid password or access token.");
         }
         if(password && (this.username == null || this.username.isEmpty())) {
             throw new InvalidCredentialsException("Invalid username.");
         }
+
         McLoginResponse response = null;
         if(password) {
             response = getLoginResponseFromCreds(this.username, this.password);
+        } else if (refresh) {
+            response = getLoginResponseFromRefreshToken();
         } else if(!device) {
             this.deviceCode = getAuthCode().device_code;
         }
 
-        if (!password) {
+        if (!password && !refresh) {
             response = getLoginResponseFromCode();
         }
 
@@ -358,6 +406,28 @@ public class MsaAuthenticationService extends AuthenticationService {
         }
     }
 
+    private static class MsRefreshRequest {
+        private String client_id;
+        private String refresh_token;
+        private String grant_type;
+
+        protected MsRefreshRequest(String clientId, String refreshToken) {
+            this.client_id = clientId;
+            this.refresh_token = refreshToken;
+            this.grant_type = "refresh_token";
+        }
+
+        public Map<String, String> toMap() {
+            Map<String, String> map = new HashMap<>();
+
+            map.put("client_id", client_id);
+            map.put("refresh_token", refresh_token);
+            map.put("grant_type", grant_type);
+
+            return map;
+        }
+    }
+
     private static class XblAuthRequest {
         private String RelyingParty;
         private String TokenType;
@@ -421,7 +491,8 @@ public class MsaAuthenticationService extends AuthenticationService {
         public String message;
     }
 
-    private static class MsTokenResponse {
+    // Public so users can access the refresh_token for offline access
+    public static class MsTokenResponse {
         public String token_type;
         public String scope;
         public int expires_in;

--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -163,7 +163,7 @@ public class MsaAuthenticationService extends AuthenticationService {
             throw new ServiceUnavailableException("Could not make request to '" + urlPost + "'.", e);
         }
 
-        MsTokenRequest request = new MsTokenRequest(code);
+        MsTokenRequest request = new MsTokenRequest(clientId, code);
         MsTokenResponse response = HTTP.makeRequestForm(this.getProxy(), MS_TOKEN_ENDPOINT, request.toMap(), MsTokenResponse.class);
 
         return getLoginResponseFromToken(response.access_token);
@@ -337,8 +337,8 @@ public class MsaAuthenticationService extends AuthenticationService {
         private String redirect_uri;
         private String scope;
 
-        protected MsTokenRequest(String code) {
-            this.client_id = "00000000402b5328";
+        protected MsTokenRequest(String clientId, String code) {
+            this.client_id = clientId;
             this.code = code;
             this.grant_type = "authorization_code";
             this.redirect_uri = "https://login.live.com/oauth20_desktop.srf";


### PR DESCRIPTION
Essentially a re-do of #15. This allows users to refresh tokens; save a refresh token for later use; and authenticate using a refresh token.

To refresh the tokens, call:

```java
// Initialize MsaAuthenticationService and authenticate somehow
auth.login();

// Some time later when the access token has expired
MsaAuthenticationService.MsTokenResponse response = auth.refreshToken();
System.out.println(response.refresh_token);
```

In order to authenticate using a previously saved refresh token, you must first set only the **username** and **refresh token** for a `MsaAuthenticationService` like so:

```java
MsaAuthenticationService auth = new MsaAuthenticationService(AZURE_CLIENT_ID);
auth.setUsername(USERNAME);          // A Microsoft account email
auth.setRefreshToken(REFRESH_TOKEN); // Refresh token from previous step
auth.login(); // Internally authenticates using the refresh token
```