### PR TITLE
Added check for `MojangAuthenticationService` Microsoft migration eligibility

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
@@ -139,7 +139,7 @@ public class MojangAuthenticationService extends AuthenticationService {
      * @return True if the account can be migrated, otherwise false.
      * @throws RequestException If an error occurs while making the request.
      */
-    public boolean msaMigrationCheck() throws RequestException {
+    public boolean canMigrate() throws RequestException {
         if (!this.loggedIn) {
             throw new RequestException("Cannot check migration eligibility while not logged in.");
         }

--- a/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
@@ -6,13 +6,11 @@ import com.github.steveice10.mc.auth.exception.request.RequestException;
 import com.github.steveice10.mc.auth.util.HTTP;
 
 import java.net.URI;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public class MojangAuthenticationService extends AuthenticationService {
     private static final URI DEFAULT_BASE_URI = URI.create("https://authserver.mojang.com/");
+    private static final URI MSA_MIGRATION_CHECK_URI = URI.create("https://api.minecraftservices.com/rollout/v1/msamigration");
     private static final String AUTHENTICATE_ENDPOINT = "authenticate";
     private static final String REFRESH_ENDPOINT = "refresh";
     private static final String INVALIDATE_ENDPOINT = "invalidate";
@@ -135,6 +133,29 @@ public class MojangAuthenticationService extends AuthenticationService {
         this.selectedProfile = response.selectedProfile;
     }
 
+    /**
+     * Checks if the current profile is eligible to migrate to a Microsoft account.
+     *
+     * @return True if the account can be migrated, otherwise false.
+     * @throws RequestException If an error occurs while making the request.
+     */
+    public boolean msaMigrationCheck() throws RequestException {
+        if (!this.loggedIn) {
+            throw new RequestException("Cannot check migration eligibility while not logged in.");
+        }
+
+        Map<String, String> authHeaders = Collections.singletonMap("Authorization", String.format("Bearer %s", this.accessToken));
+        MsaMigrationCheckResponse response = HTTP.makeRequest(this.getProxy(), MSA_MIGRATION_CHECK_URI, null, MsaMigrationCheckResponse.class, authHeaders);
+
+        if (response == null) {
+            throw new RequestException("Server returned invalid response.");
+        } else if (!response.feature.equals("msamigration")) {
+            throw new RequestException("Migration eligibility check failed unexpectedly. Are you using a legacy account?");
+        }
+
+        return response.rollout;
+    }
+
     @Override
     public String toString() {
         return "MojangUserAuthentication{clientToken=" + this.clientToken + ", username=" + this.username + ", accessToken=" + this.accessToken + ", loggedIn=" + this.loggedIn + ", profiles=" + this.profiles + ", selectedProfile=" + this.selectedProfile + "}";
@@ -201,5 +222,10 @@ public class MojangAuthenticationService extends AuthenticationService {
         public GameProfile selectedProfile;
         public GameProfile[] availableProfiles;
         public User user;
+    }
+
+    private static class MsaMigrationCheckResponse {
+        public String feature;
+        public boolean rollout;
     }
 }


### PR DESCRIPTION
Lets users check if their Mojang (non-Classic) account is eligible for an upgrade to a Microsoft account.

**Example usage:**

```java
MojangAuthenticationService auth = new MojangAuthenticationService();
auth.setUsername("account@email.com");
auth.setPassword("password");
auth.login();

if (auth.isLoggedIn()) {
    System.out.printf("%s can migrate to Microsoft: %s%n", auth.getSelectedProfile().getName(), auth.canMigrate());
}
```