### PR TITLE
Remove unused and broken import from HTTP.java

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/util/HTTP.java
+++ b/src/main/java/com/github/steveice10/mc/auth/util/HTTP.java
@@ -5,7 +5,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import jdk.nashorn.internal.objects.NativeArray;
 
 import java.io.*;
 import java.net.HttpURLConnection;


### PR DESCRIPTION
Package `jdk.nashorn.internal.objects` does not exist anymore, so I removed the import. The import was unused.