### PR TITLE
Bump maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
The version previously used no longer works. Bumping to the latest version allows javadocs to once again be built.