### PR TITLE
Fix: use mutable list for profiles

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
@@ -87,7 +87,10 @@ public class MojangAuthenticationService extends AuthenticationService {
         }
 
         this.accessToken = response.accessToken;
-        this.profiles = response.availableProfiles != null ? Arrays.asList(response.availableProfiles) : Collections.<GameProfile>emptyList();
+        this.profiles.clear();
+        if (response.availableProfiles != null) {
+            profiles.addAll(Arrays.asList(response.availableProfiles));
+        }
         this.selectedProfile = response.selectedProfile;
 
         this.properties.clear();

--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -223,7 +223,8 @@ public class MsaAuthenticationService extends AuthenticationService {
         McProfileResponse response = HTTP.makeRequest(this.getProxy(), MC_PROFILE_ENDPOINT, null, McProfileResponse.class, headers);
 
         this.selectedProfile = new GameProfile(response.id, response.name);
-        this.profiles = Collections.singletonList(this.selectedProfile);
+        this.profiles.clear();
+        this.profiles.add(this.selectedProfile);
         this.username = response.name;
     }
 


### PR DESCRIPTION
Instead of using unmodifiable lists for storing game profiles, now the initial ArrayList is cleared and reused.

Using unmodifiable lists breaks the logout method because the remove method has no implementation in those unmodifiable lists and therefor throws an UnsupportedOperationException:
![grafik](https://user-images.githubusercontent.com/27054324/148645201-9b82ebdf-9439-484c-8de6-0f8603e28cba.png)
