### PR TITLE
supports unofficial yggdrasil (authlib-injector)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ testing
 *.iml
 .idea
 
+**/.DS_Store

--- a/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java
+++ b/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java
@@ -24,6 +24,7 @@ public class MinecraftAuthTest {
     private static final Proxy PROXY = Proxy.NO_PROXY;
 
     public static void main(String[] args) throws RequestException {
+        ServiceRoot.setProxy(PROXY);
         ServiceRoot.registerYggdrasilServiceRoot(AUTHLIB_INJECTION_URI);
         profileLookup();
         auth();

--- a/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java
+++ b/example/com/github/steveice10/mc/auth/test/MinecraftAuthTest.java
@@ -5,9 +5,13 @@ import com.github.steveice10.mc.auth.exception.request.RequestException;
 import com.github.steveice10.mc.auth.service.AuthenticationService;
 import com.github.steveice10.mc.auth.service.MojangAuthenticationService;
 import com.github.steveice10.mc.auth.service.ProfileService;
+import com.github.steveice10.mc.auth.service.ServiceRoot;
 import com.github.steveice10.mc.auth.service.SessionService;
 
 import java.net.Proxy;
+import java.net.URI;
+import java.util.List;
+import java.util.Scanner;
 import java.util.UUID;
 
 public class MinecraftAuthTest {
@@ -15,12 +19,21 @@ public class MinecraftAuthTest {
     private static final String EMAIL = "Username@mail.com";
     private static final String PASSWORD = "Password";
     private static final boolean REQUIRE_SECURE_TEXTURES = true;
+    private static final URI AUTHLIB_INJECTION_URI = URI.create("https://example.yggdrasil.com/api/yggdrasil/"); // must end with a "/"!
 
     private static final Proxy PROXY = Proxy.NO_PROXY;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws RequestException {
+        ServiceRoot.registerYggdrasilServiceRoot(AUTHLIB_INJECTION_URI);
         profileLookup();
         auth();
+    }
+
+    private static int readInt() {
+        Scanner sc = new Scanner(System.in);
+        int result =  sc.nextInt();
+        sc.close();
+        return result;
     }
 
     private static void profileLookup() {
@@ -60,6 +73,13 @@ public class MinecraftAuthTest {
 
         auth = login(clientToken, auth.getAccessToken(), true);
         GameProfile profile = auth.getSelectedProfile();
+        if (profile == null) {
+            System.out.println("Select a profile:");
+            List<GameProfile> profiles = auth.getAvailableProfiles();
+            for (int i = 0; i < profiles.size(); ++i)
+                System.out.println(String.format("%d) %s", i, profiles.get(i)));
+            profile = profiles.get(readInt());
+        }
         try {
             service.fillProfileProperties(profile);
 

--- a/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MojangAuthenticationService.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import java.util.*;
 
 public class MojangAuthenticationService extends AuthenticationService {
-    private static final URI DEFAULT_BASE_URI = URI.create("https://authserver.mojang.com/");
     private static final URI MSA_MIGRATION_CHECK_URI = URI.create("https://api.minecraftservices.com/rollout/v1/msamigration");
     private static final String AUTHENTICATE_ENDPOINT = "authenticate";
     private static final String REFRESH_ENDPOINT = "refresh";
@@ -31,7 +30,7 @@ public class MojangAuthenticationService extends AuthenticationService {
      * @param clientToken Client token to use when making authentication requests.
      */
     public MojangAuthenticationService(String clientToken) {
-        super(DEFAULT_BASE_URI);
+        super(ServiceRoot.getAuthURI());
 
         if(clientToken == null) {
             throw new IllegalArgumentException("ClientToken cannot be null.");
@@ -143,6 +142,8 @@ public class MojangAuthenticationService extends AuthenticationService {
         if (!this.loggedIn) {
             throw new RequestException("Cannot check migration eligibility while not logged in.");
         }
+        if (!ServiceRoot.canMigrate())
+            return false;
 
         Map<String, String> authHeaders = Collections.singletonMap("Authorization", String.format("Bearer %s", this.accessToken));
         MsaMigrationCheckResponse response = HTTP.makeRequest(this.getProxy(), MSA_MIGRATION_CHECK_URI, null, MsaMigrationCheckResponse.class, authHeaders);

--- a/src/main/java/com/github/steveice10/mc/auth/service/ProfileService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/ProfileService.java
@@ -16,7 +16,6 @@ import java.util.UUID;
  * Repository for looking up profiles by name.
  */
 public class ProfileService extends Service {
-    private static final URI DEFAULT_BASE_URI = URI.create("https://api.mojang.com/profiles/");
     private static final String SEARCH_ENDPOINT = "minecraft";
 
     private static final int MAX_FAIL_COUNT = 3;
@@ -28,7 +27,7 @@ public class ProfileService extends Service {
      * Creates a new ProfileService instance.
      */
     public ProfileService() {
-        super(DEFAULT_BASE_URI);
+        super(ServiceRoot.getProfileURI());
     }
 
     /**

--- a/src/main/java/com/github/steveice10/mc/auth/service/ServiceRoot.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/ServiceRoot.java
@@ -30,6 +30,7 @@ public class ServiceRoot {
     private static URI sessionUri = DEFAULT_SESSION_URI;
     private static String[] whitelistedDomains = DEFAULT_WHITELISTED_DOMAINS;
     private static PublicKey signatureKey;
+    private static Proxy proxy;
 
     static {
         try (InputStream in = SessionService.class.getResourceAsStream("/yggdrasil_session_pubkey.der")) {
@@ -52,6 +53,8 @@ public class ServiceRoot {
     public static boolean canMigrate() { return rootUri == null; }
     public static String[] getWhitelistedDomains() { return whitelistedDomains; }
     public static PublicKey getSignatureKey() { return signatureKey; }
+    public static Proxy getProxy() { return proxy; }
+    public static void setProxy(Proxy proxy) { ServiceRoot.proxy = proxy; }
 
     /**
      * Register Yggdrasil service root URI.
@@ -67,7 +70,7 @@ public class ServiceRoot {
             ServiceRoot.profileUri = rootUri.resolve("api/profiles/");
             ServiceRoot.sessionUri = rootUri.resolve("sessionserver/session/minecraft/");
 
-            ServiceMetaData metaData = HTTP.makeRequest(Proxy.NO_PROXY, rootUri, null, ServiceRoot.ServiceMetaData.class);
+            ServiceMetaData metaData = HTTP.makeRequest(getProxy(), rootUri, null, ServiceRoot.ServiceMetaData.class);
             List<String> domains = new ArrayList<>();
             domains.addAll(Arrays.asList(DEFAULT_WHITELISTED_DOMAINS));
             domains.addAll(Arrays.asList(metaData.skinDomains));

--- a/src/main/java/com/github/steveice10/mc/auth/service/ServiceRoot.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/ServiceRoot.java
@@ -1,0 +1,102 @@
+package com.github.steveice10.mc.auth.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.Proxy;
+import java.net.URI;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.github.steveice10.mc.auth.exception.request.RequestException;
+import com.github.steveice10.mc.auth.util.Base64;
+import com.github.steveice10.mc.auth.util.HTTP;
+
+public class ServiceRoot {
+    private static final URI DEFAULT_AUTH_URI = URI.create("https://authserver.mojang.com/");
+    private static final URI DEFAULT_PROFILE_URI = URI.create("https://api.mojang.com/profiles/");
+    private static final URI DEFAULT_SESSION_URI = URI.create("https://sessionserver.mojang.com/session/minecraft/");
+    private static final String[] DEFAULT_WHITELISTED_DOMAINS = { ".minecraft.net", ".mojang.com" };
+    private static final PublicKey DEFAULT_SIGNATURE_KEY;
+
+    private static URI rootUri = null;
+    private static URI authUri = DEFAULT_AUTH_URI;
+    private static URI profileUri = DEFAULT_PROFILE_URI;
+    private static URI sessionUri = DEFAULT_SESSION_URI;
+    private static String[] whitelistedDomains = DEFAULT_WHITELISTED_DOMAINS;
+    private static PublicKey signatureKey;
+
+    static {
+        try (InputStream in = SessionService.class.getResourceAsStream("/yggdrasil_session_pubkey.der")) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int length = -1;
+            while ((length = in.read(buffer)) != -1)
+                out.write(buffer, 0, length);
+            out.close();
+            DEFAULT_SIGNATURE_KEY = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(out.toByteArray()));
+            signatureKey = DEFAULT_SIGNATURE_KEY;
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError("Missing/invalid yggdrasil public key.");
+        }
+    }
+
+    public static URI getAuthURI() { return authUri; }
+    public static URI getProfileURI() { return profileUri; }
+    public static URI getSessionURI() { return sessionUri; }
+    public static boolean canMigrate() { return rootUri == null; }
+    public static String[] getWhitelistedDomains() { return whitelistedDomains; }
+    public static PublicKey getSignatureKey() { return signatureKey; }
+
+    /**
+     * Register Yggdrasil service root URI.
+     *
+     * @param rootUri             The root of unofficial Yggdrasil service. Leave space
+     *                            if you want to turn back to the official one.
+     * @throws RequestException   If an error occurs while making the request.
+     */
+    public static void registerYggdrasilServiceRoot(URI rootUri) throws RequestException {
+        if (rootUri != null) {
+            ServiceRoot.rootUri = rootUri;
+            ServiceRoot.authUri = rootUri.resolve("authserver/");
+            ServiceRoot.profileUri = rootUri.resolve("api/profiles/");
+            ServiceRoot.sessionUri = rootUri.resolve("sessionserver/session/minecraft/");
+
+            ServiceMetaData metaData = HTTP.makeRequest(Proxy.NO_PROXY, rootUri, null, ServiceRoot.ServiceMetaData.class);
+            List<String> domains = new ArrayList<>();
+            domains.addAll(Arrays.asList(DEFAULT_WHITELISTED_DOMAINS));
+            domains.addAll(Arrays.asList(metaData.skinDomains));
+            ServiceRoot.whitelistedDomains = domains.toArray(new String[domains.size()]);
+            
+            String publickeyPem = metaData.signaturePublickey;
+            publickeyPem = publickeyPem.replace("-----BEGIN PUBLIC KEY-----\n","");
+            publickeyPem = publickeyPem.replace("-----END PUBLIC KEY-----","");
+            byte[] encoded = Base64.decode(publickeyPem.getBytes());
+            try {
+                signatureKey = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(encoded));
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            } catch (InvalidKeySpecException e) {
+                e.printStackTrace();
+            }
+        } else {
+            ServiceRoot.rootUri = rootUri;
+            ServiceRoot.authUri = DEFAULT_AUTH_URI;
+            ServiceRoot.profileUri = DEFAULT_PROFILE_URI;
+            ServiceRoot.sessionUri = DEFAULT_SESSION_URI;
+            ServiceRoot.whitelistedDomains = DEFAULT_WHITELISTED_DOMAINS;
+            ServiceRoot.signatureKey = DEFAULT_SIGNATURE_KEY;
+        }
+    }
+
+    public static class ServiceMetaData {
+        public Object meta;
+        public String[] skinDomains;
+        public String signaturePublickey;
+    }
+}

--- a/src/main/java/com/github/steveice10/mc/auth/service/SessionService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/SessionService.java
@@ -25,7 +25,6 @@ import java.util.UUID;
  * Service used for session-related queries.
  */
 public class SessionService extends Service {
-    private static final URI DEFAULT_BASE_URI = URI.create("https://sessionserver.mojang.com/session/minecraft/");
     private static final String JOIN_ENDPOINT = "join";
     private static final String HAS_JOINED_ENDPOINT = "hasJoined";
     private static final String PROFILE_ENDPOINT = "profile";
@@ -34,7 +33,7 @@ public class SessionService extends Service {
      * Creates a new SessionService instance.
      */
     public SessionService() {
-        super(DEFAULT_BASE_URI);
+        super(ServiceRoot.getSessionURI());
     }
 
     /**


### PR DESCRIPTION
Simply use the code below to change an unofficial Yggdrasil server:

```java
ServiceRoot.registerYggdrasilServiceRoot(URI.create("https://example.com/api/yggdrasil/")); // the suffix "/" is necessary!
```

Or if you want to change back to Mojang's official one:

```java
ServiceRoot.registerYggdrasilServiceRoot(null);
```