### PR TITLE
Fix credential-based microsoft authentication

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
+++ b/src/main/java/com/github/steveice10/mc/auth/service/MsaAuthenticationService.java
@@ -126,7 +126,7 @@ public class MsaAuthenticationService extends AuthenticationService {
             HttpURLConnection connection = HTTP.createUrlConnection(this.getProxy(), MS_LOGIN_ENDPOINT);
             connection.setDoInput(true);
             try (InputStream in = connection.getResponseCode() == 200 ? connection.getInputStream() : connection.getErrorStream()) {
-                cookies = String.join("; ", connection.getHeaderFields().get("Set-Cookie"));
+                cookies = String.join("; ", connection.getHeaderFields().getOrDefault("Set-Cookie", Collections.emptyList()));
                 String body = inputStreamToString(in);
                 Matcher m = PPFT_PATTERN.matcher(body);
                 if (m.find()) {


### PR DESCRIPTION
- Microsoft adds multiple `Set-Cookie` headers in their response, which this change now respects.
- Additionally, the used ClientID in the `oauth20_token.srf`-Route is invalid and should be equal to the one from the login endpoint (otherwise the granted code is invalid due to different environments)
- Removed the unused parameters from `MsAuthenticationService#getLoginResponseFromCreds` (No need for deprecation as this method is private either way)
Fixes #27 