### PR TITLE
Allow null name and id

### DIFF
--- a/src/main/java/com/github/steveice10/mc/auth/data/GameProfile.java
+++ b/src/main/java/com/github/steveice10/mc/auth/data/GameProfile.java
@@ -96,12 +96,8 @@ public class GameProfile {
      * @param name Name of the profile.
      */
     public GameProfile(UUID id, String name) {
-        if(id == null && (name == null || name.equals(""))) {
-            throw new IllegalArgumentException("Name and ID cannot both be blank");
-        } else {
-            this.id = id;
-            this.name = name;
-        }
+        this.id = id;
+        this.name = name;
     }
 
     /**


### PR DESCRIPTION
This constraint seems to have been changed in 1.20.2 (authlib-5.0.47). 
To follow vanilla more closely, uuid should default to 0, and name should default to a blank string.